### PR TITLE
boards: nrf54h20dk: move start of application owned memory

### DIFF
--- a/boards/nordic/nrf54h20dk/Kconfig.defconfig
+++ b/boards/nordic/nrf54h20dk/Kconfig.defconfig
@@ -22,7 +22,7 @@ config FLASH_LOAD_OFFSET
 # This is meant to span 'cpuapp_boot_partition' and 'cpuapp_slot0_partition'
 # in the default memory map.
 config FLASH_LOAD_SIZE
-	default 0x64000
+	default 0x65000
 
 endif # !USE_DT_CODE_PARTITION
 

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
@@ -200,16 +200,16 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		cpuapp_boot_partition: partition@2c000 {
-			reg = <0x2c000 DT_SIZE_K(64)>;
+		cpuapp_boot_partition: partition@2a000 {
+			reg = <0x2a000 DT_SIZE_K(64)>;
 		};
 
-		cpuapp_slot0_partition: partition@3c000 {
-			reg = <0x3c000 DT_SIZE_K(336)>;
+		cpuapp_slot0_partition: partition@3a000 {
+			reg = <0x3a000 DT_SIZE_K(340)>;
 		};
 
-		cpurad_slot0_partition: partition@90000 {
-			reg = <0x90000 DT_SIZE_K(336)>;
+		cpurad_slot0_partition: partition@8f000 {
+			reg = <0x8f000 DT_SIZE_K(340)>;
 		};
 
 		cpuppr_code_partition: partition@e4000 {
@@ -221,15 +221,15 @@
 		};
 
 		cpuapp_slot1_partition: partition@100000 {
-			reg = <0x100000 DT_SIZE_K(336)>;
+			reg = <0x100000 DT_SIZE_K(340)>;
 		};
 
-		cpurad_slot1_partition: partition@154000 {
-			reg = <0x154000 DT_SIZE_K(336)>;
+		cpurad_slot1_partition: partition@155000 {
+			reg = <0x155000 DT_SIZE_K(340)>;
 		};
 
-		storage_partition: partition@1a8000 {
-			reg = <0x1a8000 DT_SIZE_K(40)>;
+		storage_partition: partition@1aa000 {
+			reg = <0x1aa000 DT_SIZE_K(40)>;
 		};
 	};
 };

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp_0_9_0.yaml
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp_0_9_0.yaml
@@ -10,7 +10,7 @@ toolchain:
   - zephyr
 sysbuild: true
 ram: 256
-flash: 400
+flash: 404
 supported:
   - adc
   - can

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad_0_9_0.yaml
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad_0_9_0.yaml
@@ -10,7 +10,7 @@ toolchain:
   - zephyr
 sysbuild: true
 ram: 192
-flash: 336
+flash: 340
 supported:
   - counter
   - gpio


### PR DESCRIPTION
IronSide SE reserves all memory up to 0x0e02a000, use all remaining memory in the default memory map.