### PR TITLE
boards: nrf54h20dk: move start of application owned memory

### DIFF
--- a/boards/nordic/nrf54h20dk/Kconfig.defconfig
+++ b/boards/nordic/nrf54h20dk/Kconfig.defconfig
@@ -22,7 +22,7 @@ config FLASH_LOAD_OFFSET
 # This is meant to span 'cpuapp_boot_partition' and 'cpuapp_slot0_partition'
 # in the default memory map.
 config FLASH_LOAD_SIZE
-	default 0x64000
+	default 0x62000
 
 endif # !USE_DT_CODE_PARTITION
 

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20-memory_map.dtsi
@@ -200,16 +200,16 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		cpuapp_boot_partition: partition@2c000 {
-			reg = <0x2c000 DT_SIZE_K(64)>;
+		cpuapp_boot_partition: partition@30000 {
+			reg = <0x30000 DT_SIZE_K(64)>;
 		};
 
-		cpuapp_slot0_partition: partition@3c000 {
-			reg = <0x3c000 DT_SIZE_K(336)>;
+		cpuapp_slot0_partition: partition@40000 {
+			reg = <0x40000 DT_SIZE_K(328)>;
 		};
 
-		cpurad_slot0_partition: partition@90000 {
-			reg = <0x90000 DT_SIZE_K(336)>;
+		cpurad_slot0_partition: partition@92000 {
+			reg = <0x92000 DT_SIZE_K(328)>;
 		};
 
 		cpuppr_code_partition: partition@e4000 {
@@ -221,15 +221,15 @@
 		};
 
 		cpuapp_slot1_partition: partition@100000 {
-			reg = <0x100000 DT_SIZE_K(336)>;
+			reg = <0x100000 DT_SIZE_K(328)>;
 		};
 
-		cpurad_slot1_partition: partition@154000 {
-			reg = <0x154000 DT_SIZE_K(336)>;
+		cpurad_slot1_partition: partition@152000 {
+			reg = <0x152000 DT_SIZE_K(328)>;
 		};
 
-		storage_partition: partition@1a8000 {
-			reg = <0x1a8000 DT_SIZE_K(40)>;
+		storage_partition: partition@1a4000 {
+			reg = <0x1a4000 DT_SIZE_K(40)>;
 		};
 	};
 };

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp_0_9_0.yaml
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpuapp_0_9_0.yaml
@@ -10,7 +10,7 @@ toolchain:
   - zephyr
 sysbuild: true
 ram: 256
-flash: 400
+flash: 392
 supported:
   - adc
   - can

--- a/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad_0_9_0.yaml
+++ b/boards/nordic/nrf54h20dk/nrf54h20dk_nrf54h20_cpurad_0_9_0.yaml
@@ -10,7 +10,7 @@ toolchain:
   - zephyr
 sysbuild: true
 ram: 192
-flash: 336
+flash: 328
 supported:
   - counter
   - gpio


### PR DESCRIPTION
IronSide SE reserves all memory up to 0x0e030000, update memory map accordingly.